### PR TITLE
Fav with add/delete remote instruction memory persistent

### DIFF
--- a/client/src/app/main/fav.message.directive.js
+++ b/client/src/app/main/fav.message.directive.js
@@ -36,12 +36,14 @@ class FavController {
         $scope.message.fav = !$scope.message.fav;
         if($scope.message.fav == true){
             $scope.message.fav_count += 1;            
+            $scope.$parent.main.postFav($scope.message);       
         }else{
             $scope.message.fav_count -= 1;            
+            $scope.$parent.main.postRmFav($scope.message);       
         }        
         $scope.$parent.$apply();
         $log.info("fav clicked");
-        $scope.$parent.main.postFav($scope.message);       
+        
     }
   }
 }   

--- a/client/src/app/main/main.controller.js
+++ b/client/src/app/main/main.controller.js
@@ -21,5 +21,9 @@ export class MainController {
   postFav(message){
     this.robochat.postFav(message);
   }
+    
+  postRmFav(message){
+    this.robochat.postRmFav(message);
+  }
 
 }

--- a/client/src/app/main/main.jade
+++ b/client/src/app/main/main.jade
@@ -23,7 +23,7 @@ div
           header
             span.member(data-ng-bind="message.member")
             span.timestamp(data-ng-bind="message.ts | date:'HH:mm:ss'")
-            div(fav-message='0') test
+            div(fav-message)
           div(data-ng-bind="message.text")
           footer
     footer

--- a/client/src/app/main/robochat.service.js
+++ b/client/src/app/main/robochat.service.js
@@ -2,7 +2,7 @@ export class RoboChat {
 
   constructor (listener) {
 
-    let ws = new WebSocket("ws://localhost:8080/realtime")
+    let ws = new WebSocket("ws://localhost:8000/realtime")
 
     ws.onopen = (event) => {
       console.log(event);
@@ -68,9 +68,13 @@ export class RoboChat {
   }
   postFav(message){
     message.type = "fav";
-    //message.fav = false;
+ 
     //this.ws.send(JSON.stringify({ text: message.text, fav_count: message.fav_count, member: message.member }));
        this.ws.send(JSON.stringify(message));
   }
-
+ postRmFav(message){
+    message.type = "del_fav";   
+    //this.ws.send(JSON.stringify({ text: message.text, fav_count: message.fav_count, member: message.member }));
+    this.ws.send(JSON.stringify(message));
+  }
 }

--- a/client/src/app/main/robochat.service.js
+++ b/client/src/app/main/robochat.service.js
@@ -2,7 +2,7 @@ export class RoboChat {
 
   constructor (listener) {
 
-    let ws = new WebSocket("ws://localhost:8000/realtime")
+    let ws = new WebSocket("ws://localhost:8080/realtime")
 
     ws.onopen = (event) => {
       console.log(event);

--- a/server/src/main/java/com/woorea/robochat/RoboChat.java
+++ b/server/src/main/java/com/woorea/robochat/RoboChat.java
@@ -117,7 +117,7 @@ public class RoboChat {
 
       });
 
-      server.requestHandler(router::accept).listen(8000);
+      server.requestHandler(router::accept).listen(8080);
 
     }
   public static Message getMessageCache(final List<Message> messages, final String text){

--- a/server/src/main/java/com/woorea/robochat/model/Message.java
+++ b/server/src/main/java/com/woorea/robochat/model/Message.java
@@ -1,0 +1,93 @@
+package com.woorea.robochat.model;
+
+import com.fasterxml.jackson.databind.util.JSONPObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by lempere on 11/4/2015.
+ */
+public class Message {
+
+    public String message;
+    public int fav_count;
+    public String creator;
+    public List<String> users;
+    public long time;
+
+    public Message(String message) {
+        this.message = message;
+        fav_count = 0;
+        users = new ArrayList<>();
+    }
+
+    public Message(JsonObject input) {
+        this.message = input.getString("text");
+        this.creator = input.getString("member");
+        fav_count = 0;
+        time = input.getLong("ts");
+        users = new ArrayList<>();
+    }
+
+    public boolean addFav(final String user_ask){
+        for(String user : users ){
+            if( user.equals(user_ask) ){
+                return false;
+            }
+        }
+        users.add(user_ask);
+        fav_count++;
+        return true;
+    }
+    public boolean deleteFav(final String user_ask){
+        for(String user : users ){
+            if( user.equals(user_ask) ){
+                users.remove(user);
+                fav_count--;
+                if(fav_count<0) fav_count=0;
+                return true;
+            }
+        }
+        return false;
+
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public int getFav_count() {
+        return fav_count;
+    }
+
+    public void setFav_count(int fav_count) {
+        this.fav_count = fav_count;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+    public long getTime() {
+        return time;
+    }
+
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    public String toFavString() {
+        return "{\"text\":\""+getMessage()+"\",\"type\":\"fav\",\"fav_count\":"+getFav_count()+
+                " ,\"member\":\""+getCreator()+"\",\"ts\":"+getTime()+"}";
+    }
+}


### PR DESCRIPTION
Now fav not depends on the user counter instruction and the fav_count is stored in server memory
fav message type store user in the message that was made fav.
Add del_fav comunication to remove the users that was made a fav.
Remove ='0' from fav-message in main.jade is not useful.
